### PR TITLE
(#6) client supplied PQL queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 nohup.out
 discover.json
 pdbproxy
+.vscode

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -22,9 +23,9 @@ type Config struct {
 }
 
 type factFilter struct {
-	Fact     string `json: "fact"`
-	Operator string `json: "operator"`
-	Value    string `json: "value"`
+	Fact     string `json:"fact"`
+	Operator string `json:"operator"`
+	Value    string `json:"value"`
 }
 
 type mcoFilter struct {
@@ -32,8 +33,8 @@ type mcoFilter struct {
 	Classes    []string     `json:"classes"`
 	Agents     []string     `json:"agents"`
 	Identities []string     `json:"identities"`
-	Collective string       `json: "collective"`
-	Query      string       `json: "query"`
+	Collective string       `json:"collective"`
+	Query      string       `json:"query"`
 	NodeSet    string       `json:"node_set"`
 }
 
@@ -89,15 +90,10 @@ func MCollectiveDiscover(response http.ResponseWriter, request *http.Request) {
 
 func newRequest(query io.Reader) (mcoFilter, error) {
 	req := mcoFilter{}
-	req.Facts = []factFilter{}
-	req.Classes = []string{}
-	req.Agents = []string{}
-	req.Identities = []string{}
-	req.Collective = ""
-	req.Query = ""
-	req.NodeSet = ""
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(query)
 
-	if err := json.NewDecoder(query).Decode(&req); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &req); err != nil {
 		return req, errors.New("Could not decode JSON request: " + err.Error())
 	}
 

--- a/discovery/puppetdb.go
+++ b/discovery/puppetdb.go
@@ -26,11 +26,13 @@ type puppetDbResult struct {
 	Deactivated *string `json:"deactivated"`
 }
 
-// Performs discovery against PuppetDB
+// Discover nodes against PuppetDB
 func (p PuppetDB) Discover(request mcoFilter) ([]string, error) {
-	p.Log.Debugf("Query: %s", p.parseMCollectiveQuery(request))
+	query := p.parseMCollectiveQuery(request)
 
-	if result, err := p.queryPuppetdb(url.QueryEscape(p.parseMCollectiveQuery(request))); err == nil {
+	p.Log.Debugf("Query: %s", query)
+
+	if result, err := p.queryPuppetdb(url.QueryEscape(query)); err == nil {
 		if discovered, err := p.extractCertnames(result); err == nil {
 			p.Log.Debugf("Discovered %d nodes", len(discovered))
 
@@ -126,7 +128,7 @@ func (p PuppetDB) stringRegexi(needle string) string {
 		derived = needle
 	}
 
-	for idx, _ := range derived {
+	for idx := range derived {
 		if regexp.MustCompile(`[[:alpha:]]`).MatchString(string(derived[idx])) {
 			buffer.WriteString(fmt.Sprintf(`[%s%s]`, strings.ToUpper(string(derived[idx])), strings.ToLower(string(derived[idx]))))
 		} else {
@@ -173,9 +175,9 @@ func (p PuppetDB) discoverClasses(classes []string) string {
 
 	if len(queries) > 0 {
 		return strings.Join(queries, " and ")
-	} else {
-		return ""
 	}
+
+	return ""
 }
 
 // Create a PQL query string to find nodes with certain agents
@@ -197,9 +199,9 @@ func (p PuppetDB) discoverAgents(agents []string) string {
 
 	if len(queries) > 0 {
 		return strings.Join(queries, " and ")
-	} else {
-		return ""
 	}
+
+	return ""
 }
 
 // Create a PQL query string to find nodes with certain certnames
@@ -229,9 +231,9 @@ func (p PuppetDB) discoverIdentities(identities []string) string {
 
 	if len(queries) > 0 {
 		return strings.Join(queries, " or ")
-	} else {
-		return ""
 	}
+
+	return ""
 }
 
 // Creates a PQL querty string to find facts with MCollective operators supported and mapped
@@ -257,9 +259,9 @@ func (p PuppetDB) discoverFacts(facts []factFilter) string {
 
 	if len(queries) > 0 {
 		return strings.Join(queries, " and ")
-	} else {
-		return ""
 	}
+
+	return ""
 }
 
 // Extract all active certnames from quety results
@@ -283,6 +285,10 @@ func (p PuppetDB) extractCertnames(discovered []byte) ([]string, error) {
 
 // Parse the incoming MCollective discovery request and turns it into a PQL query
 func (p PuppetDB) parseMCollectiveQuery(query mcoFilter) string {
+	if query.Query != "" {
+		return (query.Query)
+	}
+
 	var queries []string
 
 	if query.Collective != "" {


### PR DESCRIPTION
Add the abilit to supply PQL queries, these queries will still only
return mathcing certnames so they have to be carefully structured to
always return certnames

Given that the proxy then attempts to extract just certnames this
ability to run arbitrary queries does not expose additional information
though could in theory be abused to look for example for nodes where
certain known vulnerable passwords are set perhaps, if this becomes a
problem it could be something that can be disabled as a feature. Though
the same issue is in -I pql:....