### PR TITLE
(#7) Add node sets

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,6 +1,9 @@
 package discovery
 
 import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/boltdb/bolt"
 	"github.com/choria-io/pdbproxy/models"
 	"github.com/choria-io/pdbproxy/restapi/operations"
 	"github.com/go-openapi/runtime/middleware"
@@ -17,17 +20,25 @@ type Config struct {
 	Certificate  string
 	PrivateKey   string
 	Ca           string
+	DBFile       string
 }
 
 var config Config
+var db *bolt.DB
 
-func SetConfig(c Config) {
+func SetConfig(c Config) error {
 	config = c
+
+	if err := openDB(); err != nil {
+		log.Fatalf("Could not open db %s: %s", config.DBFile, err.Error())
+		return err
+	}
+
+	return nil
 }
 
-func SwaggerDiscovery(params operations.GetDiscoverParams) middleware.Responder {
+func Discover(params operations.GetDiscoverParams) middleware.Responder {
 	provider := PuppetDB{}
-
 	discovered, err := provider.Discover(params.Request)
 
 	if err == nil {
@@ -35,4 +46,72 @@ func SwaggerDiscovery(params operations.GetDiscoverParams) middleware.Responder 
 	}
 
 	return operations.NewGetDiscoverBadRequest().WithPayload(&models.ErrorModel{Status: 400, Message: "Could not discover nodes: " + err.Error()})
+}
+
+func UpdateSet(params operations.PostSetParams) middleware.Responder {
+	set := Sets{DB: db}
+
+	err := set.Update(params.Set)
+
+	if err == nil {
+		return operations.NewPostSetOK().WithPayload(&models.SuccessModel{Status: 200, Detail: "Updated node set"})
+	}
+
+	return operations.NewPostSetBadRequest().WithPayload(&models.ErrorModel{Status: 400, Message: "Could not update set: " + err.Error()})
+
+}
+
+func DeleteSet(params operations.DeleteSetSetParams) middleware.Responder {
+	set := Sets{DB: db}
+
+	err := set.Delete(params.Set)
+
+	if err == nil {
+		return operations.NewPostSetOK().WithPayload(&models.SuccessModel{Status: 200, Detail: "Deleted node set"})
+	}
+
+	return operations.NewPostSetBadRequest().WithPayload(&models.ErrorModel{Status: 400, Message: "Could not update set: " + err.Error()})
+
+}
+
+func GetSet(params operations.GetSetSetParams) middleware.Responder {
+	set := Sets{DB: db}
+
+	answer, err := set.GetSet(params.Set)
+
+	if err != nil {
+		log.Infof("Searching for set %s failed: %s", params.Set, err.Error())
+		return operations.NewGetSetSetNotFound()
+	}
+
+	if answer.Set == "" {
+		return operations.NewGetSetSetNotFound()
+	}
+
+	if *params.Discover {
+		req := models.DiscoveryRequest{Query: *answer.Query}
+		provider := PuppetDB{}
+		discovered, err := provider.Discover(&req)
+
+		if err == nil {
+			answer.Nodes = discovered
+		} else {
+			return operations.NewGetSetSetBadRequest().WithPayload(&models.ErrorModel{Status: 400, Message: "Could not discover set nodes: " + err.Error()})
+		}
+	}
+
+	return operations.NewGetSetSetOK().WithPayload(answer)
+}
+
+func openDB() error {
+	bdb, err := bolt.Open(config.DBFile, 0600, nil)
+
+	if err != nil {
+		log.Fatalf("Could not open db %s: %s", config.DBFile, err.Error())
+		return err
+	}
+
+	db = bdb
+
+	return nil
 }

--- a/discovery/sets.go
+++ b/discovery/sets.go
@@ -1,0 +1,70 @@
+package discovery
+
+import (
+	"encoding/json"
+	"errors"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/boltdb/bolt"
+	"github.com/choria-io/pdbproxy/models"
+)
+
+type Sets struct {
+	DB *bolt.DB
+}
+
+func (s Sets) GetSet(setName string) (*models.Set, error) {
+	log.Infof("Retrieving set %s", setName)
+
+	set := models.Set{}
+
+	err := s.DB.View(func(tx *bolt.Tx) error {
+		tx.CreateBucketIfNotExists([]byte("choria"))
+		b := tx.Bucket([]byte("choria"))
+		val := b.Get([]byte(setName))
+
+		if len(val) == 0 {
+			return errors.New("Could not find set " + setName)
+		}
+
+		json.Unmarshal(val, &set)
+
+		return nil
+	})
+
+	return &set, err
+}
+
+func (s Sets) Delete(set string) error {
+	log.Info("Deleting set %s", set)
+
+	err := s.DB.Update(func(tx *bolt.Tx) error {
+		tx.CreateBucketIfNotExists([]byte("choria"))
+		b := tx.Bucket([]byte("choria"))
+		err := b.Delete([]byte(set))
+
+		return err
+	})
+
+	return err
+}
+
+func (s Sets) Update(request *models.Set) error {
+	log.Infof("Updating set %s", request.Set)
+
+	err := s.DB.Update(func(tx *bolt.Tx) error {
+		tx.CreateBucketIfNotExists([]byte("choria"))
+		b := tx.Bucket([]byte("choria"))
+
+		j, err := json.Marshal(request)
+		if err != nil {
+			return err
+		}
+
+		err = b.Put([]byte(request.Set), j)
+
+		return err
+	})
+
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,22 @@ func main() {
 func setupHandlers(api *operations.PdbproxyAPI) {
 	api.GetDiscoverHandler = operations.GetDiscoverHandlerFunc(
 		func(params operations.GetDiscoverParams) middleware.Responder {
-			return discovery.SwaggerDiscovery(params)
+			return discovery.Discover(params)
+		})
+
+	api.PostSetHandler = operations.PostSetHandlerFunc(
+		func(params operations.PostSetParams) middleware.Responder {
+			return discovery.UpdateSet(params)
+		})
+
+	api.DeleteSetSetHandler = operations.DeleteSetSetHandlerFunc(
+		func(params operations.DeleteSetSetParams) middleware.Responder {
+			return discovery.DeleteSet(params)
+		})
+
+	api.GetSetSetHandler = operations.GetSetSetHandlerFunc(
+		func(params operations.GetSetSetParams) middleware.Responder {
+			return discovery.GetSet(params)
 		})
 }
 
@@ -86,6 +101,7 @@ func configure() error {
 	kingpin.Flag("cert", "Public certificate file").OverrideDefaultFromEnvar("CERT").Required().ExistingFileVar(&config.Certificate)
 	kingpin.Flag("key", "Public key file").OverrideDefaultFromEnvar("KEY").Required().ExistingFileVar(&config.PrivateKey)
 	kingpin.Flag("logfile", "File to log to, STDOUT when not set").OverrideDefaultFromEnvar("LOGFILE").StringVar(&config.Logfile)
+	kingpin.Flag("db", "Path to the database file to write").OverrideDefaultFromEnvar("DB").Required().StringVar(&config.DBFile)
 
 	kingpin.Parse()
 
@@ -109,7 +125,9 @@ func configure() error {
 		log.SetLevel(log.InfoLevel)
 	}
 
-	discovery.SetConfig(config)
+	if err := discovery.SetConfig(config); err != nil {
+		os.Exit(1)
+	}
 
 	return nil
 }

--- a/models/discovery_request.go
+++ b/models/discovery_request.go
@@ -30,9 +30,6 @@ type DiscoveryRequest struct {
 	// identities
 	Identities IdentitiesFilter `json:"identities"`
 
-	// node set
-	NodeSet Word `json:"node_set,omitempty"`
-
 	// PQL Query
 	// Min Length: 1
 	Query string `json:"query,omitempty"`
@@ -43,11 +40,6 @@ func (m *DiscoveryRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateCollective(formats); err != nil {
-		// prop
-		res = append(res, err)
-	}
-
-	if err := m.validateNodeSet(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -72,22 +64,6 @@ func (m *DiscoveryRequest) validateCollective(formats strfmt.Registry) error {
 	if err := m.Collective.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("collective")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *DiscoveryRequest) validateNodeSet(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.NodeSet) { // not required
-		return nil
-	}
-
-	if err := m.NodeSet.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("node_set")
 		}
 		return err
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -78,7 +78,7 @@ func init() {
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/set"
+            "$ref": "#/responses/success"
           },
           "400": {
             "$ref": "#/responses/error"
@@ -136,7 +136,7 @@ func init() {
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/set"
+            "$ref": "#/responses/success"
           },
           "404": {
             "description": "Not found"
@@ -178,9 +178,6 @@ func init() {
         },
         "identities": {
           "$ref": "#/definitions/identitiesFilter"
-        },
-        "node_set": {
-          "$ref": "#/definitions/word"
         },
         "query": {
           "description": "PQL Query",

--- a/restapi/operations/delete_set_set_responses.go
+++ b/restapi/operations/delete_set_set_responses.go
@@ -14,7 +14,7 @@ import (
 // DeleteSetSetOKCode is the HTTP code returned for type DeleteSetSetOK
 const DeleteSetSetOKCode int = 200
 
-/*DeleteSetSetOK Node Set
+/*DeleteSetSetOK Basic successful request
 
 swagger:response deleteSetSetOK
 */
@@ -23,7 +23,7 @@ type DeleteSetSetOK struct {
 	/*
 	  In: Body
 	*/
-	Payload *models.Set `json:"body,omitempty"`
+	Payload *models.SuccessModel `json:"body,omitempty"`
 }
 
 // NewDeleteSetSetOK creates DeleteSetSetOK with default headers values
@@ -32,13 +32,13 @@ func NewDeleteSetSetOK() *DeleteSetSetOK {
 }
 
 // WithPayload adds the payload to the delete set set o k response
-func (o *DeleteSetSetOK) WithPayload(payload *models.Set) *DeleteSetSetOK {
+func (o *DeleteSetSetOK) WithPayload(payload *models.SuccessModel) *DeleteSetSetOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the delete set set o k response
-func (o *DeleteSetSetOK) SetPayload(payload *models.Set) {
+func (o *DeleteSetSetOK) SetPayload(payload *models.SuccessModel) {
 	o.Payload = payload
 }
 

--- a/restapi/operations/post_set_responses.go
+++ b/restapi/operations/post_set_responses.go
@@ -14,7 +14,7 @@ import (
 // PostSetOKCode is the HTTP code returned for type PostSetOK
 const PostSetOKCode int = 200
 
-/*PostSetOK Node Set
+/*PostSetOK Basic successful request
 
 swagger:response postSetOK
 */
@@ -23,7 +23,7 @@ type PostSetOK struct {
 	/*
 	  In: Body
 	*/
-	Payload *models.Set `json:"body,omitempty"`
+	Payload *models.SuccessModel `json:"body,omitempty"`
 }
 
 // NewPostSetOK creates PostSetOK with default headers values
@@ -32,13 +32,13 @@ func NewPostSetOK() *PostSetOK {
 }
 
 // WithPayload adds the payload to the post set o k response
-func (o *PostSetOK) WithPayload(payload *models.Set) *PostSetOK {
+func (o *PostSetOK) WithPayload(payload *models.SuccessModel) *PostSetOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the post set o k response
-func (o *PostSetOK) SetPayload(payload *models.Set) {
+func (o *PostSetOK) SetPayload(payload *models.SuccessModel) {
 	o.Payload = payload
 }
 

--- a/restapi/server.go
+++ b/restapi/server.go
@@ -31,7 +31,6 @@ var defaultSchemes []string
 
 func init() {
 	defaultSchemes = []string{
-		schemeHTTP,
 		schemeHTTPS,
 	}
 }

--- a/schema.yaml
+++ b/schema.yaml
@@ -64,7 +64,7 @@ paths:
           type: string
       responses:
         200:
-          $ref: '#/responses/set'
+          $ref: '#/responses/success'
         404:
           description: "Not found"
 
@@ -84,7 +84,7 @@ paths:
             $ref: '#/definitions/set'
       responses:
         "200":
-          $ref: '#/responses/set'
+          $ref: '#/responses/success'
         '400':
           $ref: '#/responses/error'
 
@@ -162,6 +162,7 @@ definitions:
     type: string
     minLength: 1
     pattern: '^[a-zA-Z0-9_\-\.]+$'
+
   wordOrRegex:
     type: string
     minLength: 1
@@ -220,6 +221,3 @@ definitions:
         description: PQL Query
         type: string
         minLength: 1
-      node_set:
-        $ref: '#/definitions/word'
-


### PR DESCRIPTION
A node set is a named PQL query that can later be queried using

    -I set:bobs_machines

This includes CRUD for maintaining the sets and stores them in a local
boltdb