### PR TITLE
(misc) update docs and improve REST structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ pdbproxy
 .vscode
 *.db
 *.bak
+vendor
+*.swp

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project provides a proxy service that listens on HTTP and HTTPS for discove
 
 This way the PuppetDB query interface only have to be opened to the proxy and not to everyone.
 
-Additionally it provides a way to store PQL queries and give them names.  You can thus create a PQL query that match a subset of machines and store them as `bobs_machines`, later discover will be able to refer to this set in identity filters with `-I set: bobs_machines`.
+Additionally it provides a way to store PQL queries and give them names.  You can thus create a PQL query that match a subset of machines and store them as `bobs_machines`, later discover will be able to refer to this set in identity filters with `-I set:bobs_machines`.
 
 ## Starting
 
@@ -38,6 +38,183 @@ Optional flags:
       --logfile=LOGFILE         File to log to, STDOUT when not set
 ```
 
+## Data Storage
+
+Data is stored in a [BoltDB](https://github.com/boltdb/bolt) instance in the path you specify.  BoltDB locks the store so you can only have single access to it.  To make a backup of this file you have to hit */v1/backup* with a simple GET request, this will make `your.db.bak`, you can safely back this file up.
+
+This backup file may be smaller than the main data base that's because the backup also compacts the store.  There are some CLI tools listed in the BoltDB README that you can use to view the data in the backup.
+
 ## API Format
 
 The API is defined in a Swagger API found in `schema.yaml` and can be previewed on the [Swagger UI](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/choria-io/pdbproxy/master/schema.yaml).
+
+## Sample Requests
+
+### Discovery
+The discovery requests look a lot like those that MCollective `Util::empty_filter` produce, full details are in the Swagger schema but here some examples:
+
+Filter that do not apply to your request can be left out, you can combine them along the same rules as any MCollective discovery would work - generally they get boolean `AND`d together.
+
+Discovery filters are made using *GET* to */v1/discover*, the JSON goes in the body.
+
+#### Facts
+
+<details>
+<summary>-F country=mt</summary>
+
+```json
+{
+	"facts": [
+		{
+			"fact": "country",
+			"operator": "==",
+			"value": "mt"
+		}
+	]
+}
+```
+</details>
+
+<details>
+<summary>-F lsbdistdescription=/centos/</summary>
+
+```json
+{
+	"facts": [
+		{
+			"fact": "lsbdistdescription",
+			"operator": "=~",
+			"value": "/centos/"
+		}
+	]
+}
+```
+</details>
+
+#### Classes
+
+<details>
+<summary>-C nats -C /puppetdb/</summary>
+
+```json
+{
+	"classes": [
+        "nats",
+        "/puppetdb/"
+	]
+}
+```
+</details>
+
+#### Agents
+
+<details>
+<summary>-A apache -A /weather/</summary>
+
+```json
+{
+	"agents": [
+        "apache",
+        "/weather/"
+	]
+}
+```
+</details>
+
+#### Identities
+
+<details>
+<summary>-I /web/</summary>
+
+```json
+{
+	"identities": [
+        "/web/"
+	]
+}
+```
+</details>
+
+<details>
+<summary>-I pql:nodes {}</summary>
+
+```json
+{
+	"identities": [
+        "pql:nodes {}"
+	]
+}
+```
+</details>
+
+<details>
+<summary>-I set:bobs_machines</summary>
+
+```json
+{
+	"identities": [
+        "set:bobs_machines"
+	]
+}
+```
+</details>
+
+#### PQL
+
+This is not really used by MCollective but it's handy.
+
+<details>
+<summary>arbitrary PQL</summary>
+
+```json
+{
+	"queries": [
+        "nodes {}"
+	]
+}
+```
+</details>
+
+### Set maintenance
+
+Set names must match *^[a-zA-Z0-9_\\-\\.]+$*
+
+#### List Sets
+
+GET request to */v1/sets*
+
+#### Create a Set
+
+<details>
+<summary>POST /v1/set</summary>
+
+```json
+{
+	"set": "test_set",
+	"query": "nodes { (certname in inventory[certname] { facts.mcollective.server.collectives.match(\"\\d+\") = \"mt_collective\" }) }",
+	"nodes": []
+}
+```
+</details>
+
+#### Retrieve a Set
+
+Do a GET against */v1/set/test_set* you can also request the node list to be included like */v1/set/test_set?discover=true*
+
+#### Update a Set
+
+<details>
+<summary>PUT /v1/set/test_set</summary>
+
+```json
+{
+	"set": "test_set",
+	"query": "nodes { (certname in inventory[certname] { facts.mcollective.server.collectives.match(\"\\d+\") = \"mt_collective\" }) }",
+	"nodes": []
+}
+```
+</details>
+
+#### Delete a Set
+
+Do a DELETE against */v1/set/test_set*

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 )
 
+// Config for the discovery service
 type Config struct {
 	Listen       string
 	Port         int
@@ -26,6 +27,7 @@ type Config struct {
 var config Config
 var db *bolt.DB
 
+// SetConfig allows callers to configure the service
 func SetConfig(c Config) error {
 	config = c
 
@@ -37,6 +39,7 @@ func SetConfig(c Config) error {
 	return nil
 }
 
+// BackupSets produces a BoltDB backup in a file called .bak
 func BackupSets(params operations.GetBackupParams) middleware.Responder {
 	set := Sets{DB: db}
 
@@ -45,39 +48,42 @@ func BackupSets(params operations.GetBackupParams) middleware.Responder {
 	err := set.Backup(&target)
 
 	if err == nil {
-		return operations.NewGetBackupOK().WithPayload(&models.SuccessModel{Status: 200, Detail: "Created backup file " + target})
+		return operations.NewGetBackupOK().WithPayload(&models.SuccessModel{Code: 200, Message: "Created backup file " + target})
 	}
 
-	return operations.NewGetBackupInternalServerError().WithPayload(&models.ErrorModel{Status: 500, Message: "Could not create backup: " + err.Error()})
+	return operations.NewGetBackupInternalServerError().WithPayload(&models.ErrorModel{Code: 500, Message: "Could not create backup: " + err.Error()})
 }
 
+// Discover does basic MCollective like discovery against PuppetDB
 func Discover(params operations.GetDiscoverParams) middleware.Responder {
 	provider := PuppetDB{}
 	discovered, err := provider.Discover(params.Request)
 
 	if err == nil {
-		return operations.NewGetDiscoverOK().WithPayload(&models.DiscoverySuccessModel{Status: 200, Nodes: discovered})
+		return operations.NewGetDiscoverOK().WithPayload(&models.DiscoverySuccessModel{Code: 200, Nodes: discovered})
 	}
 
-	return operations.NewGetDiscoverBadRequest().WithPayload(&models.ErrorModel{Status: 400, Message: "Could not discover nodes: " + err.Error()})
+	return operations.NewGetDiscoverBadRequest().WithPayload(&models.ErrorModel{Code: 400, Message: "Could not discover nodes: " + err.Error()})
 }
 
+// CreateSet will make new sets
 func CreateSet(params operations.PostSetParams) middleware.Responder {
 	set := Sets{DB: db}
 
 	if set.Exists(string(params.Set.Set)) {
-		return operations.NewPostSetBadRequest().WithPayload(&models.ErrorModel{Status: 400, Message: "A set called " + string(params.Set.Set) + " already exist"})
+		return operations.NewPostSetBadRequest().WithPayload(&models.ErrorModel{Code: 400, Message: "A set called " + string(params.Set.Set) + " already exist"})
 	}
 
 	err := set.Update(params.Set)
 
 	if err == nil {
-		return operations.NewPostSetOK().WithPayload(&models.SuccessModel{Status: 200, Detail: "Created node set"})
+		return operations.NewPostSetOK().WithPayload(&models.SuccessModel{Code: 200, Message: "Created node set"})
 	}
 
-	return operations.NewPostSetInternalServerError().WithPayload(&models.ErrorModel{Status: 500, Message: "Could not create set: " + err.Error()})
+	return operations.NewPostSetInternalServerError().WithPayload(&models.ErrorModel{Code: 500, Message: "Could not create set: " + err.Error()})
 }
 
+// UpdateSet will update an existing set with new parameters
 func UpdateSet(params operations.PutSetSetParams) middleware.Responder {
 	set := Sets{DB: db}
 
@@ -88,12 +94,13 @@ func UpdateSet(params operations.PutSetSetParams) middleware.Responder {
 	err := set.Update(params.NewSet)
 
 	if err == nil {
-		return operations.NewPutSetSetOK().WithPayload(&models.SuccessModel{Status: 200, Detail: "Updated node set"})
+		return operations.NewPutSetSetOK().WithPayload(&models.SuccessModel{Code: 200, Message: "Updated node set"})
 	}
 
-	return operations.NewPutSetSetInternalServerError().WithPayload(&models.ErrorModel{Status: 500, Message: "Could not update set: " + err.Error()})
+	return operations.NewPutSetSetInternalServerError().WithPayload(&models.ErrorModel{Code: 500, Message: "Could not update set: " + err.Error()})
 }
 
+// DeleteSet will remove an already existing set
 func DeleteSet(params operations.DeleteSetSetParams) middleware.Responder {
 	set := Sets{DB: db}
 
@@ -104,12 +111,13 @@ func DeleteSet(params operations.DeleteSetSetParams) middleware.Responder {
 	err := set.Delete(params.Set)
 
 	if err == nil {
-		return operations.NewDeleteSetSetOK().WithPayload(&models.SuccessModel{Status: 200, Detail: "Deleted node set"})
+		return operations.NewDeleteSetSetOK().WithPayload(&models.SuccessModel{Code: 200, Message: "Deleted node set"})
 	}
 
-	return operations.NewDeleteSetSetInternalServerError().WithPayload(&models.ErrorModel{Status: 500, Message: "Could not update set: " + err.Error()})
+	return operations.NewDeleteSetSetInternalServerError().WithPayload(&models.ErrorModel{Code: 500, Message: "Could not update set: " + err.Error()})
 }
 
+// GetSet retrieves the parameters of a set and optionally does a discovery
 func GetSet(params operations.GetSetSetParams) middleware.Responder {
 	set := Sets{DB: db}
 
@@ -121,7 +129,7 @@ func GetSet(params operations.GetSetSetParams) middleware.Responder {
 
 	if err != nil {
 		log.Errorf("Retrieving set %s failed: %s", params.Set, err.Error())
-		return operations.NewGetSetSetInternalServerError().WithPayload(&models.ErrorModel{Status: 500, Message: "Retrieving set failed: " + err.Error()})
+		return operations.NewGetSetSetInternalServerError().WithPayload(&models.ErrorModel{Code: 500, Message: "Retrieving set failed: " + err.Error()})
 	}
 
 	if *params.Discover {
@@ -132,19 +140,20 @@ func GetSet(params operations.GetSetSetParams) middleware.Responder {
 		if err == nil {
 			answer.Nodes = discovered
 		} else {
-			return operations.NewGetSetSetInternalServerError().WithPayload(&models.ErrorModel{Status: 500, Message: "Could not discover set nodes: " + err.Error()})
+			return operations.NewGetSetSetInternalServerError().WithPayload(&models.ErrorModel{Code: 500, Message: "Could not discover set nodes: " + err.Error()})
 		}
 	}
 
 	return operations.NewGetSetSetOK().WithPayload(answer)
 }
 
+// ListSets finds all known sets
 func ListSets(params operations.GetSetsParams) middleware.Responder {
 	set := Sets{DB: db}
 
 	sets := set.Sets()
 
-	return operations.NewGetSetsOK().WithPayload(sets)
+	return operations.NewGetSetsOK().WithPayload(&models.Sets{Code: 200, Sets: sets})
 }
 
 func openDB() error {

--- a/discovery/puppetdb.go
+++ b/discovery/puppetdb.go
@@ -17,6 +17,7 @@ import (
 	"github.com/choria-io/pdbproxy/models"
 )
 
+// PuppetDB based discovery helpers
 type PuppetDB struct{}
 
 type puppetDbResult struct {

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,101 @@
+hash: e81c28b85c9680e258ef745a625dcec75029080c34c1c5ac3842ce613642c0d9
+updated: 2017-05-22T10:44:01.123440009+02:00
+imports:
+- name: github.com/alecthomas/template
+  version: a0175ee3bccc567396460bf5acd36800cb10c49c
+  subpackages:
+  - parse
+- name: github.com/alecthomas/units
+  version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
+- name: github.com/asaskevich/govalidator
+  version: 948702997351133e1cc5a1b5842313ca46deeb0d
+- name: github.com/boltdb/bolt
+  version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
+- name: github.com/docker/go-units
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/go-openapi/analysis
+  version: 0473cb67199f68b8b7d90e641afd9e79ad36b851
+- name: github.com/go-openapi/errors
+  version: 03cfca65330da08a5a440053faf994a3c682b5bf
+- name: github.com/go-openapi/jsonpointer
+  version: 779f45308c19820f1a69e9a4cd965f496e0da10f
+- name: github.com/go-openapi/jsonreference
+  version: 36d33bfe519efae5632669801b180bf1a245da3b
+- name: github.com/go-openapi/loads
+  version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
+- name: github.com/go-openapi/runtime
+  version: 2e9e988df6c290425033bacd425e008950c96be6
+  subpackages:
+  - flagext
+  - middleware
+  - middleware/denco
+  - middleware/header
+  - middleware/untyped
+  - security
+- name: github.com/go-openapi/spec
+  version: e51c28f07047ad90caff03f6450908720d337e0c
+- name: github.com/go-openapi/strfmt
+  version: 93a31ef21ac23f317792fff78f9539219dd74619
+- name: github.com/go-openapi/swag
+  version: e43299b4afa7bc7f22e5e82e3d48607230e4c177
+- name: github.com/go-openapi/validate
+  version: 035dcd74f1f61e83debe1c22950dc53556e7e4b2
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/jessevdk/go-flags
+  version: 48cf8722c3375517aba351d1f7577c40663a4407
+- name: github.com/mailru/easyjson
+  version: dffba8d13bbd998df17d8557570cdea0624b9d1d
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/mitchellh/mapstructure
+  version: cc8532a8e9a55ea36402aa21efdf403a60d34096
+- name: github.com/PuerkitoBio/purell
+  version: b938d81255b5473c57635324295cb0fe398c7a58
+- name: github.com/PuerkitoBio/urlesc
+  version: bbf7a2afc14f93e1e0a5c06df524fbd75e5031e5
+- name: github.com/Sirupsen/logrus
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: github.com/tylerb/graceful
+  version: 4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb
+- name: golang.org/x/net
+  version: 513929065c19401a1c7b76ecd942f9f86a0c061b
+  subpackages:
+  - context
+  - idna
+- name: golang.org/x/sys
+  version: dbc2be9168a660ef302e04b6ff6406de6f967473
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
+- name: gopkg.in/alecthomas/kingpin.v2
+  version: 7f0871f2e17818990e4eed73f9b5c2f429501228
+- name: gopkg.in/mgo.v2
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
+  subpackages:
+  - bson
+  - internal/json
+- name: gopkg.in/yaml.v2
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,33 @@
+package: github.com/choria-io/pdbproxy
+import:
+- package: github.com/Sirupsen/logrus
+  version: ~0.11.5
+- package: github.com/boltdb/bolt
+  version: ~1.3.0
+- package: github.com/choria-io/pdbproxy
+  subpackages:
+  - discovery
+  - models
+  - restapi
+  - restapi/operations
+- package: github.com/go-openapi/errors
+- package: github.com/go-openapi/loads
+- package: github.com/go-openapi/runtime
+  subpackages:
+  - flagext
+  - middleware
+- package: github.com/go-openapi/spec
+- package: github.com/go-openapi/strfmt
+- package: github.com/go-openapi/swag
+- package: github.com/go-openapi/validate
+- package: github.com/jessevdk/go-flags
+  version: ~1.2.0
+- package: github.com/tylerb/graceful
+  version: ~1.2.15
+- package: gopkg.in/alecthomas/kingpin.v2
+  version: ~2.2.4
+testImport:
+- package: github.com/stretchr/testify
+  version: ~1.1.4
+  subpackages:
+  - assert

--- a/models/discovery_success_model.go
+++ b/models/discovery_success_model.go
@@ -14,11 +14,11 @@ import (
 // swagger:model discoverySuccessModel
 type DiscoverySuccessModel struct {
 
+	// HTTP Status Code
+	Code int64 `json:"code,omitempty"`
+
 	// nodes
 	Nodes []string `json:"nodes"`
-
-	// HTTP Status Code
-	Status int64 `json:"status,omitempty"`
 }
 
 // Validate validates this discovery success model

--- a/models/error_model.go
+++ b/models/error_model.go
@@ -14,14 +14,11 @@ import (
 // swagger:model errorModel
 type ErrorModel struct {
 
-	// Extra details about the error
-	Detail string `json:"detail,omitempty"`
+	// HTTP Status Code
+	Code int64 `json:"code,omitempty"`
 
 	// Short description of the problem
 	Message string `json:"message,omitempty"`
-
-	// HTTP Status Code
-	Status int64 `json:"status,omitempty"`
 }
 
 // Validate validates this error model

--- a/models/sets.go
+++ b/models/sets.go
@@ -9,29 +9,69 @@ import (
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/swag"
 )
 
 // Sets sets
 // swagger:model sets
-type Sets []Word
+type Sets struct {
+
+	// HTTP Status Code
+	Code int64 `json:"code,omitempty"`
+
+	// sets
+	Sets []Word `json:"sets"`
+}
 
 // Validate validates this sets
-func (m Sets) Validate(formats strfmt.Registry) error {
+func (m *Sets) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	for i := 0; i < len(m); i++ {
+	if err := m.validateSets(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
 
-		if err := m[i].Validate(formats); err != nil {
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Sets) validateSets(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Sets) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Sets); i++ {
+
+		if err := m.Sets[i].Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName(strconv.Itoa(i))
+				return ve.ValidateName("sets" + "." + strconv.Itoa(i))
 			}
 			return err
 		}
 
 	}
 
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *Sets) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
 	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *Sets) UnmarshalBinary(b []byte) error {
+	var res Sets
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
 	return nil
 }

--- a/models/success_model.go
+++ b/models/success_model.go
@@ -14,11 +14,11 @@ import (
 // swagger:model successModel
 type SuccessModel struct {
 
-	// detail
-	Detail string `json:"detail,omitempty"`
-
 	// HTTP Status Code
-	Status int64 `json:"status,omitempty"`
+	Code int64 `json:"code,omitempty"`
+
+	// message
+	Message string `json:"message,omitempty"`
 }
 
 // Validate validates this success model

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -265,15 +265,15 @@ func init() {
     "discoverySuccessModel": {
       "type": "object",
       "properties": {
+        "code": {
+          "description": "HTTP Status Code",
+          "type": "integer"
+        },
         "nodes": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "status": {
-          "description": "HTTP Status Code",
-          "type": "integer"
         }
       },
       "additionalProperties": false
@@ -281,17 +281,13 @@ func init() {
     "errorModel": {
       "type": "object",
       "properties": {
-        "detail": {
-          "description": "Extra details about the error",
-          "type": "string"
+        "code": {
+          "description": "HTTP Status Code",
+          "type": "integer"
         },
         "message": {
           "description": "Short description of the problem",
           "type": "string"
-        },
-        "status": {
-          "description": "HTTP Status Code",
-          "type": "integer"
         }
       },
       "additionalProperties": false
@@ -359,20 +355,29 @@ func init() {
       }
     },
     "sets": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/word"
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "HTTP Status Code",
+          "type": "integer"
+        },
+        "sets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/word"
+          }
+        }
       }
     },
     "successModel": {
       "type": "object",
       "properties": {
-        "detail": {
-          "type": "string"
-        },
-        "status": {
+        "code": {
           "description": "HTTP Status Code",
           "type": "integer"
+        },
+        "message": {
+          "type": "string"
         }
       }
     },

--- a/restapi/operations/get_sets_responses.go
+++ b/restapi/operations/get_sets_responses.go
@@ -23,7 +23,7 @@ type GetSetsOK struct {
 	/*
 	  In: Body
 	*/
-	Payload models.Sets `json:"body,omitempty"`
+	Payload *models.Sets `json:"body,omitempty"`
 }
 
 // NewGetSetsOK creates GetSetsOK with default headers values
@@ -32,13 +32,13 @@ func NewGetSetsOK() *GetSetsOK {
 }
 
 // WithPayload adds the payload to the get sets o k response
-func (o *GetSetsOK) WithPayload(payload models.Sets) *GetSetsOK {
+func (o *GetSetsOK) WithPayload(payload *models.Sets) *GetSetsOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get sets o k response
-func (o *GetSetsOK) SetPayload(payload models.Sets) {
+func (o *GetSetsOK) SetPayload(payload *models.Sets) {
 	o.Payload = payload
 }
 
@@ -46,13 +46,10 @@ func (o *GetSetsOK) SetPayload(payload models.Sets) {
 func (o *GetSetsOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(200)
-	payload := o.Payload
-	if payload == nil {
-		payload = make(models.Sets, 0, 50)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
-
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
-	}
-
 }

--- a/schema.yaml
+++ b/schema.yaml
@@ -160,7 +160,7 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      status:
+      code:
         type: integer
         description: HTTP Status Code
       nodes:
@@ -171,22 +171,19 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      status:
+      code:
         type: integer
         description: HTTP Status Code
       message:
         type: string
         description: Short description of the problem
-      detail:
-        type: string
-        description: Extra details about the error
   successModel:
     type: object
     properties:
-      status:
+      code:
         type: integer
         description: HTTP Status Code
-      detail:
+      message:
         type: string
   set:
     type: object
@@ -204,9 +201,16 @@ definitions:
         items:
           type: string
   sets:
-    type: array
-    items:
-      $ref: '#/definitions/word'
+    type: object
+    properties:
+      code:
+        type: integer
+        description: HTTP Status Code
+      sets:
+        type: array
+        items:
+          $ref: '#/definitions/word'
+          
   collectiveFilter:
     $ref: '#/definitions/word'
   word:


### PR DESCRIPTION
Documents some example of rest requests and noticed that the go-swagger
libraries will produce a JSON document with `code` and `message` on
validation fail which is different from ours and this seems impossible
to configure.

So this reworks things a bit so those errors and ours are the same

Also uses glide for vendoring